### PR TITLE
カバレッジ生成用Dockerイメージ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  test:
+    build: ./docker
+    working_dir: /usr/src/app
+    command: vendor/bin/phpunit
+    volumes:
+      - .:/usr/src/app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM php:7.1
+RUN yes "" | pecl install xdebug && docker-php-ext-enable xdebug

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
+         colors="true"
          verbose="true">
     <testsuite>
         <directory suffix="Test.php">./tests</directory>
@@ -21,5 +22,6 @@
 
     <logging>
         <log type="coverage-html" target="build/log/"/>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true" showUncoveredFiles="false"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
ローカルにcoverage driverを入れない手